### PR TITLE
Use version of `canvas-action` from package set

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,37 +1,45 @@
 {
-  "name": "purescript-grid-reactors",
-  "license": ["MIT"],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Eugleo/purescript-grid-reactors.git"
-  },
-  "ignore": ["**/.*", "node_modules", "bower_components", "output"],
-  "dependencies": {
-    "purescript-aff": "^v6.0.0",
-    "purescript-arrays": "^v6.0.1",
-    "purescript-colors": "^v6.0.0",
-    "purescript-console": "^v5.0.0",
-    "purescript-effect": "^v3.0.0",
-    "purescript-exceptions": "^v5.0.0",
-    "purescript-foldable-traversable": "^v5.0.1",
-    "purescript-canvas-action": "artemisSystem/purescript-canvas-action#43de19ee369d1ff9fe7eff1e583b828809fd9e36",
-    "purescript-free": "^v6.0.1",
-    "purescript-halogen": "^v6.1.3",
-    "purescript-halogen-hooks": "https://github.com/thomashoneyman/purescript-halogen-hooks.git#v0.5.0",
-    "purescript-halogen-subscriptions": "https://github.com/purescript-halogen/purescript-halogen-subscriptions.git#v1.0.0",
-    "purescript-heterogeneous": "^v0.5.1",
-    "purescript-integers": "^v5.0.0",
-    "purescript-maybe": "^v5.0.0",
-    "purescript-partial": "^v3.0.0",
-    "purescript-prelude": "^v5.0.1",
-    "purescript-psci-support": "^v5.0.0",
-    "purescript-random": "^v5.0.0",
-    "purescript-st": "^v5.0.1",
-    "purescript-tailrec": "^v5.0.1",
-    "purescript-transformers": "^v5.2.0",
-    "purescript-tuples": "^v6.0.1",
-    "purescript-web-events": "^v3.0.0",
-    "purescript-web-html": "^v3.1.0",
-    "purescript-web-uievents": "^v3.0.0"
-  }
+    "name": "purescript-grid-reactors",
+    "license": [
+        "MIT"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Eugleo/purescript-grid-reactors.git"
+    },
+    "ignore": [
+        "**/.*",
+        "node_modules",
+        "bower_components",
+        "output"
+    ],
+    "dependencies": {
+        "purescript-aff": "^v6.0.0",
+        "purescript-arrays": "^v6.0.1",
+        "purescript-canvas-action": "^v7.0.0",
+        "purescript-colors": "^v6.0.0",
+        "purescript-console": "^v5.0.0",
+        "purescript-effect": "^v3.0.0",
+        "purescript-exceptions": "^v5.0.0",
+        "purescript-foldable-traversable": "^v5.0.1",
+        "purescript-free": "^v6.1.0",
+        "purescript-halogen": "^v6.1.3",
+        "purescript-halogen-hooks": "https://github.com/thomashoneyman/purescript-halogen-hooks.git#v0.5.0",
+        "purescript-halogen-subscriptions": "https://github.com/purescript-halogen/purescript-halogen-subscriptions.git#v1.0.0",
+        "purescript-heterogeneous": "^v0.5.1",
+        "purescript-integers": "^v5.0.0",
+        "purescript-maybe": "^v5.0.0",
+        "purescript-newtype": "^v4.0.0",
+        "purescript-partial": "^v3.0.0",
+        "purescript-prelude": "^v5.0.1",
+        "purescript-psci-support": "^v5.0.0",
+        "purescript-random": "^v5.0.0",
+        "purescript-st": "^v5.0.1",
+        "purescript-tailrec": "^v5.0.1",
+        "purescript-transformers": "^v5.2.0",
+        "purescript-tuples": "^v6.0.1",
+        "purescript-web-events": "^v3.0.0",
+        "purescript-web-html": "^v3.2.0",
+        "purescript-web-uievents": "^v3.0.0"
+    }
 }

--- a/packages.dhall
+++ b/packages.dhall
@@ -99,35 +99,6 @@ in  upstream
 -------------------------------
 -}
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.14.4-20210905/packages.dhall sha256:140f3630801f2b02d5f3a405d4872e0af317e4ef187016a6b00f97d59d6275c6
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.5-20211111/packages.dhall sha256:7ed6350fe897a93926d16298e37d2324aabbe5eca99810204719dc3632fb555f
 
 in  upstream
-  with canvas-action =
-    { dependencies =
-      [ "aff"
-      , "arrays"
-      , "canvas"
-      , "colors"
-      , "effect"
-      , "either"
-      , "exceptions"
-      , "foldable-traversable"
-      , "math"
-      , "maybe"
-      , "numbers"
-      , "polymorphic-vectors"
-      , "prelude"
-      , "refs"
-      , "run"
-      , "transformers"
-      , "tuples"
-      , "type-equality"
-      , "typelevel-prelude"
-      , "unsafe-coerce"
-      , "web-dom"
-      , "web-events"
-      , "web-html"
-      ]
-    , repo = "https://github.com/artemisSystem/purescript-canvas-action.git"
-    , version = "43de19ee369d1ff9fe7eff1e583b828809fd9e36"
-    }


### PR DESCRIPTION
This PR makes it so `grid-reactors` depends on the version of `canvas-action` from the package set instead of an arbitrary Git tag.

As part of this, we also had to upgrade to a newer version of the package set.

### Motivation

`grid-reactors` is currently in the PureScript [package set](https://github.com/purescript/package-sets) and will need to have these dependency issues resolved in order to remain in the package set after the move to the new PureScript registry.

See https://github.com/purescript/registry/issues/250 for more details.